### PR TITLE
[development] - celery-boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # C extensions
 *.so
 
+# Dask
+*.lock
+*.dirlock
+
 # Distribution / packaging
 .Python
 build/

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -64,13 +64,14 @@ def dashboard():
         }
 
         fetch_league.delay(meta)
-        fetch_players.delay(meta)
+        # fetch_players.delay(meta)
 
-        return {'created': f'{username}, {team_id}, {league_id}'}
+        return 'Sent async requests!'
+        # return {f'created: {username}, {team_id}, {league_id}'}
 
 
 @celery.task(name='wsgi.fetch_league')
-def fetch_league(meta: dict):
+def fetch_league(meta):
     return league(
         league_id=meta['league_id'],
         year=meta['year'],
@@ -79,7 +80,7 @@ def fetch_league(meta: dict):
 
 
 @celery.task(name='wsgi.fetch_players')
-def fetch_players(meta: dict):
+def fetch_players(meta):
     return players(
         league_id=meta['league_id'],
         year=meta['year'],

--- a/pr-prep.sh
+++ b/pr-prep.sh
@@ -7,25 +7,23 @@ export PYTHONPATH=$PWD
 echo $PYTHONPATH
 
 echo "Executing black code formatting"
-pip install black
 echo " >> see (https://github.com/psf/black)"
 black src/
 echo -ne '\n'
 
 
 echo "Executing pylint - python linter"
-pip install pylint
 echo " >> see (https://github.com/PyCQA/pylint)"
 pylint src/
 echo -ne '\n'
 
 
 echo "Executing flake8 - python quality/style linter"
-pip install flake8
 echo " >> see (https://github.com/PyCQA/flake8)"
 flake8 src/
 echo -ne '\n'
 
+echo "Executing pytest - running pytest tests/"
 
 pytest --cov-report term-missing --cov=src/ -vv tests/
 

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,15 @@ setup(
      keywords='Fantasy Basketball Analytics',
      packages=find_packages(),
      install_requires=[
-         'requests',
-         'prefect',
+         'celery',
          'flask',
-         'python-dotenv',
+         'mock',
+         'prefect',
+         'prefect[postgres]',
          'prefect[viz]',
-		 'prefect[postgres]',
          'pytest',
          'pytest-cov',
-         'mock'
+         'python-dotenv',
+         'requests',
      ]
 )

--- a/src/auth.py
+++ b/src/auth.py
@@ -33,22 +33,15 @@ def espn_authenticate(user: str, pwd: str):  # pragma no cover
     response = requests.post(URL_LOGIN, headers=headers, json=payload)
 
     if response.status_code != 200:
-        AUTH_LOGGER.debug(
-            "Authentication unsuccessful - check credentials"
-        )
+        AUTH_LOGGER.debug("Authentication unsuccessful - check credentials")
         AUTH_LOGGER.debug("Retry the authentication")
         return None
 
     data = response.json()
 
     if data["error"] is not None:
-        AUTH_LOGGER.debug(
-            "Authentication unsuccessful - error: %s", data["error"]
-        )
+        AUTH_LOGGER.debug("Authentication unsuccessful - error: %s", data["error"])
         AUTH_LOGGER.debug("Retry the authentication")
         return None
 
-    return {
-        "espn_s2": data["data"]["s2"],
-        "swid": data["data"]["profile"]["swid"]
-    }
+    return {"espn_s2": data["data"]["s2"], "swid": data["data"]["profile"]["swid"]}

--- a/src/fba_league.py
+++ b/src/fba_league.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 import prefect
 import requests
 
@@ -181,7 +182,7 @@ def execute(flow: Flow, year: int, league_id: int, cookies: dict) -> state:
         league_state: (state) state of league flow
     """
     with raise_on_exception():
-        executor = DaskExecutor(address="tcp://192.168.1.4:8786")
+        executor = DaskExecutor(address=os.getenv('WORKER_ADDRESS'))
         league_state = flow.run(year=year, league_id=league_id, cookies=cookies, executor=executor)
 
         return league_state

--- a/src/fba_league.py
+++ b/src/fba_league.py
@@ -132,7 +132,10 @@ def fetch_team_meta(base_url: str, team_id: int, cookies: Parameter) -> dict:
         "isCurrentUser": is_current_user,
     }
 
-    team_meta_logger.info(f"Team: %s", json.dumps(team_meta, indent=4))
+    team_meta_logger.info(
+        f"id: {team_meta.get('id')}"
+        f"isCurrentUser {team_meta.get('isCurrentUser')}"
+    )
 
     return team_meta
 

--- a/src/fba_league.py
+++ b/src/fba_league.py
@@ -47,9 +47,7 @@ def fetch_league_meta(base_url: str, cookies: Parameter) -> dict:
 
     data = resp.json()
 
-    members = [
-        {"id": x["id"], "name": x["displayName"]} for x in data["members"]
-    ]
+    members = [{"id": x["id"], "name": x["displayName"]} for x in data["members"]]
 
     # this index zero is bothering me for now
     teams = [
@@ -134,8 +132,7 @@ def fetch_team_meta(base_url: str, team_id: int, cookies: Parameter) -> dict:
         "isCurrentUser": is_current_user,
     }
 
-    team_meta_logger.info(
-        f"Team: %s", json.dumps(team_meta, indent=4))
+    team_meta_logger.info(f"Team: %s", json.dumps(team_meta, indent=4))
 
     return team_meta
 
@@ -161,9 +158,7 @@ def build(year: int, league_id: int, cookies: dict) -> Flow:
         meta = fetch_league_meta(base_url=req, cookies=cookies)
 
         fetch_team_meta.map(
-            base_url=unmapped(req),
-            team_id=meta["team_ids"],
-            cookies=unmapped(cookies),
+            base_url=unmapped(req), team_id=meta["team_ids"], cookies=unmapped(cookies),
         )
 
         return flow
@@ -181,11 +176,7 @@ def execute(flow: Flow, year: int, league_id: int, cookies: dict) -> state:
         league_state: (state) state of league flow
     """
     with raise_on_exception():
-        league_state = flow.run(
-            year=year,
-            league_id=league_id,
-            cookies=cookies
-        )
+        league_state = flow.run(year=year, league_id=league_id, cookies=cookies)
 
         return league_state
 
@@ -203,12 +194,7 @@ def league(year: int, league_id: int, cookies: dict) -> state:
     """
     flow = build(year=year, league_id=league_id, cookies=cookies)
 
-    league_state = execute(
-        flow=flow,
-        year=year,
-        league_id=league_id,
-        cookies=cookies
-    )
+    league_state = execute(flow=flow, year=year, league_id=league_id, cookies=cookies)
 
     # flow.visualize()
 

--- a/src/fba_league.py
+++ b/src/fba_league.py
@@ -5,6 +5,8 @@ import requests
 
 from prefect import Flow, Parameter, task, unmapped
 
+from prefect.engine.executors import DaskExecutor
+
 from prefect.utilities.debug import raise_on_exception, state
 
 from .constants import FBA_ENDPOINT
@@ -179,7 +181,8 @@ def execute(flow: Flow, year: int, league_id: int, cookies: dict) -> state:
         league_state: (state) state of league flow
     """
     with raise_on_exception():
-        league_state = flow.run(year=year, league_id=league_id, cookies=cookies)
+        executor = DaskExecutor(address="tcp://192.168.1.4:8786")
+        league_state = flow.run(year=year, league_id=league_id, cookies=cookies, executor=executor)
 
         return league_state
 

--- a/src/fba_players.py
+++ b/src/fba_players.py
@@ -9,6 +9,8 @@ from prefect import (
     task,
 )
 
+from prefect.engine.executors import DaskExecutor
+
 from prefect.utilities.debug import raise_on_exception, state
 
 from src.utils.http_util import request_status
@@ -148,7 +150,8 @@ def execute(flow: Flow, year: int, league_id: int, cookies: dict) -> state:
         players_state: (state) state of league flow
     """
     with raise_on_exception():
-        players_state = flow.run(year=year, league_id=league_id, cookies=cookies)
+        executor = DaskExecutor(address="tcp://192.168.1.4:8786")
+        players_state = flow.run(year=year, league_id=league_id, cookies=cookies, executor=executor)
 
         return players_state
 

--- a/src/fba_players.py
+++ b/src/fba_players.py
@@ -109,9 +109,7 @@ def fetch_rosters(base_url: str, cookies: Parameter) -> dict:
                 }
             )
 
-        roster_logger.debug(
-            json.dumps(rosters.get(team_obj.team_id,), indent=4)
-        )
+        roster_logger.debug(json.dumps(rosters.get(team_obj.team_id,), indent=4))
 
     return rosters
 
@@ -150,11 +148,7 @@ def execute(flow: Flow, year: int, league_id: int, cookies: dict) -> state:
         players_state: (state) state of league flow
     """
     with raise_on_exception():
-        players_state = flow.run(
-            year=year,
-            league_id=league_id,
-            cookies=cookies
-        )
+        players_state = flow.run(year=year, league_id=league_id, cookies=cookies)
 
         return players_state
 
@@ -170,18 +164,9 @@ def players(year: int, league_id: int, cookies: dict) -> state:
     Returns:
         league_state: (state) state of league flow
     """
-    flow = build(
-        year=year,
-        league_id=league_id,
-        cookies=cookies
-    )
+    flow = build(year=year, league_id=league_id, cookies=cookies)
 
-    players_state = execute(
-        flow=flow,
-        year=year,
-        league_id=league_id,
-        cookies=cookies
-    )
+    players_state = execute(flow=flow, year=year, league_id=league_id, cookies=cookies)
 
     # flow.visualize()
 

--- a/src/fba_players.py
+++ b/src/fba_players.py
@@ -150,7 +150,7 @@ def execute(flow: Flow, year: int, league_id: int, cookies: dict) -> state:
         players_state: (state) state of league flow
     """
     with raise_on_exception():
-        executor = DaskExecutor(address="tcp://192.168.1.4:8786")
+        executor = DaskExecutor(address=os.getenv('WORKER_ADDRESS'))
         players_state = flow.run(year=year, league_id=league_id, cookies=cookies, executor=executor)
 
         return players_state

--- a/src/utils/flask_celery.py
+++ b/src/utils/flask_celery.py
@@ -1,7 +1,7 @@
 from celery import Celery
 
 
-def make_celery(app):
+def make_celery(app):  # pragma no cover
     """
     Instantiate celery.Celery async broker
     Args:

--- a/src/utils/flask_celery.py
+++ b/src/utils/flask_celery.py
@@ -1,0 +1,33 @@
+from celery import Celery
+
+
+def make_celery(app):
+    """
+    Instantiate celery.Celery async broker
+    Args:
+        app: (Flask) - app to broker messages for
+
+    Returns:
+         celery: (Celery)
+    """
+    celery = Celery(
+        app.import_name,
+        backend=app.config["CELERY_BACKEND"],
+        broker=app.config["CELERY_BROKER_URL"],
+    )
+
+    celery.conf.update(app.config)
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        """establish Flask application context (for call within Flask)"""
+
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask
+
+    return celery


### PR DESCRIPTION
**SETUP**
*rabbitmq*
-A few dependencies before testing in your environment
```bash
# Helpful alias
echo "alias bsl='brew services list'" >> ~/.zshrc 
source ~/.zshrc

$ brew install rabbitmq
$ brew services start rabbitmq

# Ensure its running
bsl
```
You should see
`rabbitmq started {user} {Plist}`

*celery*
-In your virtual environtment
```bash
$ pip install celery

# or rebuilt via setup.py
$ pip install -e .
```

*.env*
```python
##########
# CELERY #
##########

CELERY_BROKER_URL='amqp://localhost//'
CELERY_BACKEND='db+postgresql://{user}:{password}@{host}:{port}/{dbname}'
```

**CHANGES**
In b3fc315 thru 5dbd79b:
-Added two separate `celery.task`
-One for league flow, and one for players flow

**USAGE**
-Launch three terminals, or `bg` your background tasks
-Assuming rabbitmq is already running
```bash
# terminal 1
$ ./.run_pgadmin  # or whatever your pgadmin executable is

# terminal 2
$ source venv/bin/activate
$ cd app
$ celery -A wsgi.celery worker --loglevel=info

# terminal 3
$ source venv/bin/activate
$ python app/wsgi.py
```

Enter user data then hit the `/my-team` route
We can see in the celery worker terminal:
`Received task: wsgi.league[0cadf79e-695e-4712-85c0-f53d04│59ffaf]`

**THIS IS JUST BOILERPLATE IMPLEMENTATION**

In 53eb25b thru 69f465e:
**IMPROVEMENTS**
-Created cookie using `auth.py` to pass to `celery.tasks`

**BUGS**
-SQLAlchemy issue `TypeError: can't pickle _thread.RLock objects`
*(currently looking into this bug)*